### PR TITLE
Enable VSCode and DevContainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+	"name": "Hugo and Tools",
+	"image": "mcr.microsoft.com/devcontainers/base:debian-12",
+	"features": {
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "1.21"
+		},
+		"ghcr.io/devcontainers/features/node:1": {
+			"nodeGypDependencies": true,
+			"version": "18",
+			"nvmVersion": "0.39"
+		}
+	},
+	"forwardPorts": [1313]
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/com.thebiggerguy.www.code-workspace
+++ b/com.thebiggerguy.www.code-workspace
@@ -1,0 +1,13 @@
+{
+	"folders": [
+		{
+			"name": "Site",
+			"path": "site"
+		},
+		{
+			"name": "Root",
+			"path": "."
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
Wire up VSCode + DevContainers for a one-click development environment. VSCode is now the de facto IDE for most web project and aligns with this project been hosted via GitHub. To mitigate too much depedency and to abstract the host OS DevContainers are used.