### PR TITLE
Remove links to Twitter and add Mastodon

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -21,7 +21,7 @@ googleAnalytics = "UA-126221439-1"
 [author]
     displayName = "Guy Taylor"
     [social]
-        twitter = "TheBiggerGuy"
+        mastodon = "https://infosec.exchange/@TheBiggerGuy"
 
 [params]
     # The path must be relative to the static folder 

--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -17,17 +17,6 @@
     <meta name="og:title" content="{{ .Site.Title }}{{ with .Title }} | {{ . }}{{ end }}">
     <meta name="og:description" content="{{ .Description | default .Site.Params.SiteDescription }}">
 
-    <!-- Twitter Card data -->
-    <meta name="twitter:site" content="@TheBiggerGuy" />
-    <!-- use og:title for twitter:title -->
-    <!-- use og:description for twitter:description -->
-    {{- block "twitter_card" . }}
-    <meta name="twitter:card" content="summary">
-    {{ $hero_image := .Site.Home.Resources.GetMatch "index_hero.jpg" }}
-    {{ $hero_image_square := $hero_image.Fill "1024x1024" }}
-    <meta name="twitter:image" content="{{ $hero_image_square.Permalink }}" />
-    {{- end }}
-
     {{ "<!-- Fav Icon -->" | safeHTML }}
     {{- with resources.Get .Site.Params.favicon | resources.Fingerprint "sha256" }}
     <link rel="icon" href="{{ .Permalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous">

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -2,7 +2,7 @@
     <div class="row justify-content-center">
         <div class="col">
             <ul class="list-unstyled list-inline">
-                <a href="https://twitter.com/TheBiggerGuy"><span class="fab fa-twitter fa-3x px-2"></span></a>
+                <a href="https://infosec.exchange/@TheBiggerGuy"><span class="fab fa-mastodon fa-3x px-2"></span></a>
                 <a href="https://github.com/TheBiggerGuy"><span class="fab fa-github fa-3x px-2"></span></a>
                 <a href="https://www.linkedin.com/in/Guy-Taylor"><span class="fab fa-linkedin fa-3x px-2"></span></a>
             </ul>

--- a/site/layouts/photography/single.html
+++ b/site/layouts/photography/single.html
@@ -1,12 +1,3 @@
-{{ define "twitter_card" }}
-<meta name="twitter:card" content="summary_large_image">
-{{ $hero_image_params := index .Params.Photos 0 }}
-{{ $hero_image := .Resources.GetMatch $hero_image_params.file }}
-{{ if ne $hero_image.ResourceType "image" }}{{ errorf "Image ResourceType not jpg: %s %s" .Path $hero_image.ResourceType }}{{ end }}
-{{ $hero_image_resized := $hero_image.Fit "2048x1024" }}
-<meta name="twitter:image" content="{{ $hero_image_resized.Permalink }}" />
-{{ end }}
-
 {{ define "header" }}
 <header>
     {{ if .Title}}{{ if not .Params.hideTitle }}<h1>{{ .Title }}</h1>{{ end }}{{ end }}


### PR DESCRIPTION
Remove all Twitter references as well as custom code to support its platform. This then adds in mastodon as a footer link.