### PR TITLE
Auto deploy CloudFormation stack

### DIFF
--- a/.ci/deploy.sh
+++ b/.ci/deploy.sh
@@ -19,7 +19,26 @@ aws --version
 
 # Build the site
 hugo -s site
-# Spell Check
-# Requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
-aws s3 sync 'site/public' 's3://com.thebiggerguy.www' --region='eu-west-1' --acl='private' --delete
-aws cloudfront create-invalidation --distribution-id "${AWS_CLOUDFRONT_DISTRIBUTION_ID}" --paths '/*'
+
+# Get git hash
+if [[ -z "${GITHUB_SHA}" ]]; then
+    GIT_HASH="${GITHUB_SHA}"
+else
+    GIT_HASH="$(git describe --always --dirty)"
+fi
+echo "GitHash=${GIT_HASH}"
+
+# Requires AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or OIDC
+aws cloudformation deploy \
+    --template-file cloudformation.yaml \
+    --stack-name com-thebiggerguy-www \
+    --region='eu-west-1' \
+    --parameter-overrides "GitHash=${GIT_HASH}"
+aws s3 sync \
+    'site/public' 's3://com.thebiggerguy.www' \
+    --region='eu-west-1' \
+    --acl='private' \
+    --delete
+aws cloudfront create-invalidation \
+    --distribution-id "${AWS_CLOUDFRONT_DISTRIBUTION_ID}" \
+    --paths '/*'

--- a/.ci/install_awscli.sh
+++ b/.ci/install_awscli.sh
@@ -5,4 +5,4 @@ set -o errexit
 set -o pipefail
 
 python3 -m pip install --user --upgrade pip
-python3 -m pip install --user --upgrade awscli
+python3 -m pip install --user --upgrade git+https://github.com/aws/aws-cli.git@v2

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  GitHash:
+    Description: The Git hash used for this deployment
+    Type: String
+
+Resources:
+  Budget:
+    Type: 'AWS::Budgets::Budget'
+    Properties:
+      Budget:
+        BudgetName: com-thebiggerguy-www
+        BudgetType: COST
+        BudgetLimit:
+          Amount: 10
+          Unit: USD
+        TimeUnit: MONTHLY
+        CostTypes:
+          IncludeTax: true
+
+Outputs:
+  GitHash:
+    Description: The Git hash used for this deployment
+    Value: !Ref GitHash


### PR DESCRIPTION
Auto deploy a AWS CloudFormation stack and start making the project self describing as Infra-as-Code. This initial commit sets the ground work for later resources to be added to make the template complete.

Part of this groundwork is to update AWS CLI from v1 to v2 to enable modern features, as well as preventing dependency on legacy systems.