### PR TITLE
Work around OpenSSL issue with AWS CLI v2

### DIFF
--- a/.ci/install_awscli.sh
+++ b/.ci/install_awscli.sh
@@ -5,4 +5,5 @@ set -o errexit
 set -o pipefail
 
 python3 -m pip install --user --upgrade pip
+python3 -m pip install --user --upgrade setuptools wheel pyopenssl
 python3 -m pip install --user --upgrade git+https://github.com/aws/aws-cli.git@v2


### PR DESCRIPTION
When running the AWS CLI v2 it fails with what appears to be an OpenSSL version/compatibility issue. To work around this update to a more current version of OpenSSL

Issue:
```
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```