### PR TITLE
Update Ubuntu to work around OpenSSL issues

### DIFF
--- a/.ci/install_awscli.sh
+++ b/.ci/install_awscli.sh
@@ -5,5 +5,5 @@ set -o errexit
 set -o pipefail
 
 python3 -m pip install --user --upgrade pip
-python3 -m pip install --user --upgrade setuptools wheel pyopenssl
-python3 -m pip install --user --upgrade git+https://github.com/aws/aws-cli.git@v2
+python3 -m pip install --user --upgrade setuptools wheel
+python3 -m pip install --user --upgrade git+https://github.com/aws/aws-cli.git@2.15.28

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository and submodules
@@ -26,7 +26,7 @@ jobs:
 
   archive:
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository and submodules
@@ -80,7 +80,7 @@ jobs:
 
   deploy:
     needs: archive
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     environment: Deployment
     permissions:
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository and submodules


### PR DESCRIPTION
The prior commit fe058ca4e7d70ecfd62fb4a76da30f9465bd052f did not address the issue. Looking into the AWS CLI repo itself they do not seem to have any issues and the only difference is OS version.

https://github.com/aws/aws-cli/blob/2.15.28/.github/workflows/run-tests.yml