### PR TITLE
Update GH Action go

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
 
       - name: Configure Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '^1.11.13'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
           submodules: recursive
 
       - name: Configure Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '^1.11.13'
 


### PR DESCRIPTION
This updates the Go action to pick up new updates as well as address compatibility issues with the migration fro Node 16 to 20.

https://github.com/actions/setup-go/releases/tag/v5.0.0 https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/