### PR TITLE
Fix Images On Photography Single Pages

### DIFF
--- a/site/layouts/photography/single.html
+++ b/site/layouts/photography/single.html
@@ -14,7 +14,7 @@
     {{ range $photo := .Params.Photos }}
         {{ $photo_id = add $photo_id 1 }}
 
-        {{ with $photo_resource := $.Resources.GetMatch $photo.File }}
+        {{ with $photo_resource := $.Resources.GetMatch $photo.file }}
             {{ if ne $photo_resource.ResourceType "image" }}{{ errorf "Image ResourceType not jpg: %s" $photo_resource.ResourceType }}{{ end }}
             {{ $photo_resized_425 := $photo_resource.Fit "425x500" }}
             {{ $photo_resized_1024 := $photo_resource.Fit "1024x500" }}
@@ -25,7 +25,7 @@
                     <img src="{{ $photo_resized_425.Permalink }}" alt="{{ $.Page.Description }}" class="img-fluid">
                 </picture>
             </a>
-            <p class="text-muted">Captured on {{ dateFormat "2006-01-02" $photo.Date }} and finished on {{ dateFormat "2006-01-02" $.Page.Date }}</p>
+            <p class="text-muted">Captured on {{ dateFormat "2006-01-02" $photo.date }} and finished on {{ dateFormat "2006-01-02" $.Page.Date }}</p>
 
             <div id="picture-modal-dialog-{{ $photo_id }}" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
                 <div class="modal-dialog modal-dialog-centered modal-xl">


### PR DESCRIPTION
The photography section's single pages showed only the Google map without images or date captions. This regression was caused by a Hugo version upgrade that changed case-sensitivity behavior for nested map keys.

Root cause:
- YAML front matter uses lowercase keys: `file`, `date`, `location`
- Template used capitalized lookups: `$photo.File`, `$photo.Date`
- Hugo v0.62.0 (Dec 2019) made nested map keys case-sensitive
- Local commit 511dd46 (2022-10-03) upgraded Hugo from 0.57.2 → 0.104.2, crossing the v0.62.0 boundary and triggering the bug

Fix:
- site/layouts/photography/single.html: lowercase parameter lookups
  - Line 17: `$photo.File` → `$photo.file`
  - Line 28: `$photo.Date` → `$photo.date`

This aligns with the working list template (section/photography.html:16) which already used `$photo.file` correctly.

References:
- Hugo v0.62.0 release: https://github.com/gohugoio/hugo/releases/tag/v0.62.0
- Hugo commit a03c631: https://github.com/gohugoio/hugo/commit/a03c631c420a03f9d90699abdf9be7e4fca0ff61
- Local upgrade commit: 511dd46